### PR TITLE
Remove `npm install` from serve-mini

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ COPY --from=build-docs /opt/valadoc /opt/valadoc
 WORKDIR /opt/valadoc
 
 # Build website assets
-RUN make build-data
+RUN npm ci && make build-data
 
 # Cleanup and publish
 FROM php:apache

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,6 @@ check-examples: valadoc-example-tester
 #
 
 build-data:
-	npm install
 	npx gulp
 
 #


### PR DESCRIPTION
It just slows down the dev process and usually has no effect. The README already tells users to run this.