### PR TITLE
Add dark mode using prefers-color-scheme

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 VALAC = valac
 PACKAGES ?= --all
-GENERATOR_OPTS ?= --disable-devhelp --skip-existing
+GENERATOR_OPTS ?= --disable-devhelp
 VALAC_VERSION := $(shell vala --api-version | awk -F. '{ print "0."$$2 }')
 VAPIDIR := $(shell pkg-config --variable vapidir libvala-$(VALAC_VERSION))
 VALAFLAGS = -g -X -w

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 VALAC = valac
 PACKAGES ?= --all
-GENERATOR_OPTS ?= --disable-devhelp
+GENERATOR_OPTS ?= --disable-devhelp --skip-existing
 VALAC_VERSION := $(shell vala --api-version | awk -F. '{ print "0."$$2 }')
 VAPIDIR := $(shell pkg-config --variable vapidir libvala-$(VALAC_VERSION))
 VALAFLAGS = -g -X -w

--- a/data/scripts/valadoc.js
+++ b/data/scripts/valadoc.js
@@ -71,6 +71,19 @@ function initTooltip() {
 
 
 function setupLink (link) {
+  let shouldTrackLink = false;
+
+  const xlinkPath = link.getAttribute('xlink:href');
+  
+  // Force tooltip to show up over `<a>` element nodes in SVGs.
+  if (xlinkPath && !link.getAttribute('href')) {
+    link.setAttribute('href', xlinkPath);
+    link.hostname = location.hostname;
+    // An SVGAnimatedString is returned when getting attributes from inside an SVG.
+    // We need to use the "baseVal` field to get the actual value  we need for the pathaname.
+    link.pathname = link.href.baseVal;
+  }
+
   if (link.hostname !== location.hostname
     || link.pathname.endsWith('index.htm')
     || link.pathname.endsWith('.tar.bz2')) {

--- a/data/styles/main.css
+++ b/data/styles/main.css
@@ -138,7 +138,7 @@ nav .title img {
 }
 
 #sidebar .site_navigation a::before {
-    content: '';
+    content: "";
     display: inline-block;
     height: 16px;
     width: 16px;
@@ -183,7 +183,7 @@ nav .title img {
 
 #sidebar .external-link::after {
     background-image: url(/images/external_link.svg);
-    content: '';
+    content: "";
     display: inline-block;
     height: 12px;
     width: 12px;
@@ -249,7 +249,7 @@ nav .title img {
 
 .navi_inline li::before,
 .navi_main li::before {
-    content: '';
+    content: "";
     display: inline-block;
     height: 16px;
     width: 16px;
@@ -315,7 +315,7 @@ nav .title img {
 .highlight .package::before,
 .document::before,
 .video::before {
-    content: '';
+    content: "";
     display: inline-block;
     height: 16px;
     width: 16px;
@@ -434,6 +434,7 @@ nav .title img {
     padding: 12px;
     text-align: left;
     z-index: 1000;
+    top: -200px;
 }
 
 .tooltip * {

--- a/data/styles/main.css
+++ b/data/styles/main.css
@@ -358,6 +358,11 @@ nav .title img {
     border-style: none;
     display: block;
     margin: 0 auto;
+    text-align: center;
+}
+
+.graph > polygon {
+    fill: none;
 }
 
 .site_navi {
@@ -845,6 +850,23 @@ a.abstract_class,
     footer {
         background-color: #1a1a1a;
         color: #eee;
+    }
+
+    .graph .node polygon {
+        stroke: white;
+    }
+
+    .graph .node text {
+        fill: white;
+    }
+
+    .graph .edge path {
+        stroke: white;
+    }
+
+    .graph .edge polygon {
+        stroke: white;
+        fill:  white;
     }
 
     .tooltip {

--- a/data/styles/main.css
+++ b/data/styles/main.css
@@ -370,7 +370,7 @@ nav .title img {
 }
 
 .graph .node polygon {
-    fill: transparent
+    fill: transparent;
 }
 
 .site_navi {

--- a/data/styles/main.css
+++ b/data/styles/main.css
@@ -361,6 +361,10 @@ nav .title img {
     text-align: center;
 }
 
+.graph .node text {
+    font-size: 14px;
+}
+
 .graph > polygon {
     fill: none;
 }

--- a/data/styles/main.css
+++ b/data/styles/main.css
@@ -866,7 +866,7 @@ a.abstract_class,
 
     .graph .edge polygon {
         stroke: white;
-        fill:  white;
+        fill: white;
     }
 
     .tooltip {

--- a/data/styles/main.css
+++ b/data/styles/main.css
@@ -369,6 +369,10 @@ nav .title img {
     fill: none;
 }
 
+.graph .node polygon {
+    fill: transparent
+}
+
 .site_navi {
     text-align: right;
 }

--- a/data/styles/main.css
+++ b/data/styles/main.css
@@ -27,8 +27,8 @@ p {
 }
 
 /***********
- * Nav Bar *
- ***********/
+* Nav Bar *
+***********/
 
 nav {
     align-items: center;
@@ -115,8 +115,8 @@ nav .title img {
 }
 
 /***********
- * Sidebar *
- ***********/
+* Sidebar *
+***********/
 
 #sidebar {
     background-color: #f7f6f8;
@@ -263,8 +263,8 @@ nav .title img {
 }
 
 /***********
- * Content *
- ***********/
+* Content *
+***********/
 
 #content-wrapper {
     display: flex;
@@ -634,8 +634,8 @@ code {
 }
 
 /*********
- * Icons *
- *********/
+* Icons *
+*********/
 
 .abstract_class::before,
 a.abstract_class,
@@ -791,4 +791,67 @@ a.abstract_class,
 .description a.virtual_property,
 .brief_description a.virtual_property {
     background-image: url(/images/virtualproperty.svg);
+}
+
+@media (prefers-color-scheme: dark) {
+    body {
+        background-color: #22222a;
+        color: #eee;
+    }
+
+    nav {
+        background-color: #38304c;
+    }
+
+    #sidebar {
+        background-color: #22222a;
+        border-right-color: #111;
+    }
+
+    #sidebar li:hover {
+        background-color: rgba(0, 0, 0, 0.5);
+    }
+    .search-selected {
+        background-color: #524a66 !important;
+    }
+
+    li.namespace::before,
+    li.package_index::before {
+        filter: brightness(200%);
+    }
+
+    #sidebar a {
+        color: #eee;
+    }
+
+    .highlight:hover {
+        background-color: #111;
+    }
+
+    #sidebar hr {
+        border-top-color: #222;
+        border-bottom-color: #000;
+    }
+
+    .main_code_definition {
+        background-color: #111;
+    }
+
+    .box .headline {
+        background-color: #112;
+        border-color: #446;
+    }
+
+    footer {
+        background-color: #1a1a1a;
+        color: #eee;
+    }
+
+    .tooltip {
+        background-color: #111;
+    }
+
+    .main_parameter_table_unknown_parameter {
+        color: #999;
+    }
 }


### PR DESCRIPTION
A basic dark mode stylesheet, using the prefers-color-scheme media query. Fixes #271.

Object hierarchy graphs are still black on white. I'm not sure how to fix that yet.

Also, should the search box be light-on-dark as well? I tried it but I'm not sure if it looks right.