### PR TITLE
Fix typos

### DIFF
--- a/data/scripts/valadoc.js
+++ b/data/scripts/valadoc.js
@@ -83,7 +83,7 @@ function setupLink (link) {
   })
 
   link.addEventListener('mouseenter', evt => {
-      // fullname = path without the / at the beggining and the .htm(l)
+      // fullname = path without the / at the beginning and the .htm(l)
     const target = evt.currentTarget
     target.hovered = true
     const fullname = link.pathname.substring(1).replace(/\.html?$/, '')
@@ -126,7 +126,7 @@ function loadPage (link, popped = false) {
       document.querySelectorAll('#content a').forEach(setupLink)
       document.querySelectorAll('#content area').forEach(setupLink)
     }).catch(err => {
-      html.content.innerHTML = `<h1>Sorry, an error occured</h1><p>${err.message}</p>`
+      html.content.innerHTML = `<h1>Sorry, an error occurred</h1><p>${err.message}</p>`
     })
 
     if (html.searchField.value === '') {
@@ -181,7 +181,7 @@ document.addEventListener('DOMContentLoaded', () => {
   document.querySelectorAll('body > div a').forEach(setupLink)
   document.querySelectorAll('body > div area').forEach(setupLink)
 
-  // register some usefull shortcuts
+  // register some useful shortcuts
   document.addEventListener('keyup', evt => {
     switch (evt.keyCode) {
       case 27: // echap

--- a/documentation/glib-2.0/glib-2.0.valadoc
+++ b/documentation/glib-2.0/glib-2.0.valadoc
@@ -2812,7 +2812,7 @@ GLib.Time.gm
 GLib.Time.local
 
 /**
- * Converts the date and time information to a formated string.
+ * Converts the date and time information to a formatted string.
  *
  * @param format a date-time format. See {@link GLib.Time.format} for details.
  * @return a newly-allocated string holding the result.

--- a/documentation/gnutls/gnutls.valadoc
+++ b/documentation/gnutls/gnutls.valadoc
@@ -84,7 +84,7 @@ GnuTLS.CertificateImportFlags.LIST_IMPORT_FAIL_IF_EXCEED
 /**
  * If set a signer does not have to be a certificate authority.
  *
- * This flag should normaly be disabled, unless you know what this means.
+ * This flag should normally be disabled, unless you know what this means.
  */
 GnuTLS.CertificateVerifyFlags.DISABLE_CA_SIGN
 

--- a/documentation/libgvc/libgvc.valadoc
+++ b/documentation/libgvc/libgvc.valadoc
@@ -16,7 +16,7 @@ Gvc.initlib
  * However, note that both {@link c::gvContext} and {@link c::gvParseArgs} will call {@link c::aginit}
  * internally if necessary. It's safe to call {@link c::aginit} multiple times.
  *
- * For more information of Graphviz initialization, see documention at:
+ * For more information of Graphviz initialization, see documentation at:
  * [[http://graphviz.org/pdf/libguide.pdf]]
  */
 Gvc.init

--- a/examples/gio-2.0/gio-2.0.valadoc.examples
+++ b/examples/gio-2.0/gio-2.0.valadoc.examples
@@ -47,7 +47,7 @@
 		<node>GLib.BufferedInputStream</node>
 	</example>
 	<example>
-		<title>Charset convertion</title>
+		<title>Charset conversion</title>
 		<file>GLib.CharsetConverter.vala</file>
 		<compile>valac --pkg gio-2.0 GLib.CharsetConverter.vala</compile>
 		<node>GLib.CharsetConverter</node>

--- a/examples/glib-2.0/GLib.Memory.copy.vala
+++ b/examples/glib-2.0/GLib.Memory.copy.vala
@@ -3,7 +3,7 @@ public static int main (string[] args) {
 
 	// Copy the data into a typeless buffer:
 	// Do not copy arrays / classes / etc when you do not know what you are doing.
-	// You may break your ref counters / lose array lenght information / etc
+	// You may break your ref counters / lose array length information / etc
 	void* copy = try_malloc (sizeof (char)*data.length);
 	Memory.copy (copy, data, sizeof (char)*data.length);
 	print ("%s\n", (string) copy);

--- a/examples/glib-2.0/GLib.Memory.dup.vala
+++ b/examples/glib-2.0/GLib.Memory.dup.vala
@@ -3,7 +3,7 @@ public static int main (string[] args) {
 
 	// Copy the data into a typeless buffer:
 	// Do not copy arrays / classes / etc when you do not know what you are doing.
-	// You may break your ref counters / lose array lenght information / etc
+	// You may break your ref counters / lose array length information / etc
 	void* copy = Memory.dup (data, (uint) (sizeof (char)*data.length));
 	print ("%s\n", (string) copy);
 	free (copy);

--- a/examples/gtk+-3.0/Gtk.TreePath.vala
+++ b/examples/gtk+-3.0/Gtk.TreePath.vala
@@ -26,7 +26,7 @@ public static int main (string[] args) {
 	store.set (category_iter, 0, "Films", -1);
 
 	store.append (out product_iter, category_iter);
-	store.set (product_iter, 0, "Amores Perros", 1, "$7.99", -1);
+	store.set (product_iter, 0, "Amores Perrors", 1, "$7.99", -1);
 	store.append (out product_iter, category_iter);
 	store.set (product_iter, 0, "Twin Peaks", 1, "$14.99", -1);
 	store.append (out product_iter, category_iter);
@@ -40,7 +40,7 @@ public static int main (string[] args) {
 	//     + Ulysses				$26.09
 	//     + Effective Vala			$38.99
 	//   + Films
-	//     + Amores Perros			$7.99
+	//     + Amores Perrors			$7.99
 	//     + Twin Peaks				$14.99
 	// 	   + Vertigo				$20.49
 

--- a/examples/gtk+-3.0/Gtk.TreeStore.vala
+++ b/examples/gtk+-3.0/Gtk.TreeStore.vala
@@ -40,7 +40,7 @@ public class Application : Gtk.Window {
 		store.set (category_iter, 0, "Films", -1);
 
 		store.append (out product_iter, category_iter);
-		store.set (product_iter, 0, "Amores Perros", 1, "$7.99", -1);
+		store.set (product_iter, 0, "Amores Perrors", 1, "$7.99", -1);
 		store.append (out product_iter, category_iter);
 		store.set (product_iter, 0, "Twin Peaks", 1, "$14.99", -1);
 		store.append (out product_iter, category_iter);

--- a/examples/rest-0.7/get-fireeagle-location.vala
+++ b/examples/rest-0.7/get-fireeagle-location.vala
@@ -1,6 +1,6 @@
 // README: Fire Eagle has closed as of February 2013.
 //  This eample won't work anymore. However, the code
-//  might be usefull.
+//  might be useful.
 public static int main (string[] args) {
 	// Create the proxy:
 	Rest.OAuthProxy proxy = new Rest.OAuthProxy (

--- a/src/valadoc-example-tester.vala
+++ b/src/valadoc-example-tester.vala
@@ -127,7 +127,7 @@ public class ExampleTester : ExampleParser {
 				report_error (errmsg);
 			}
 		} else {
-			report_error ("An error occured. Please check the logs.");
+			report_error ("An error occurred. Please check the logs.");
 		}
 
 		example_experimental = false;


### PR DESCRIPTION
Hey,

This huge PR will fix : 

- 3 typos in `data/scripts/valadoc.js`
- 1 typo in `documentation/glib-2.0/glib-2.0.valadoc`
- 1 typo in `documentation/gnutls/gnutls.valadoc`
- 1 typo in `documentation/libgvc/libgvc.valadoc`
- 1 typo in `examples/gio-2.0/gio-2.0.valadoc.examples`
- 1 typo in `examples/glib-2.0/GLib.Memory.copy.vala`
- 1 typo in `examples/glib-2.0/GLib.Memory.dup.vala`
- 2 typos in `examples/gtk+-3.0/Gtk.TreePath.vala`
- 1 typo in `examples/gtk+-3.0/Gtk.TreeStore.vala`
- 1 typo in `examples/rest-0.7/get-fireeagle-location.vala`
- 1 typo in `src/valadoc-example-tester.vala`



Cheers! :robot: