### PR TITLE
Fix #295: Only try to publish on the main repo

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   Dockerhub:
+    if: github.repository == 'vala-lang/valadoc-org'
     runs-on: ubuntu-latest
     steps:
       - name: Clone


### PR DESCRIPTION
Fix #295: Disable the publish to dockerhub action on forks of the repository.