### PR TITLE
Dockerfile: Use apache-buster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 ## Builds valadoc and serves it with a basic PHP server
 
 # Cleanup and publish
-FROM php:apache
+FROM php:apache-buster
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
We are failing to build the container since bullseye is the new stable.