### PR TITLE
build: Do not disable devhelp for the standard build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
 
     - name: Build the documentation
       run: |
-        make build-docs
+        make build-docs GENERATOR_OPTS=""
 
     - name: Build search index
       run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Build the documentation
         run: |
-          make build-docs
+          make build-docs GENERATOR_OPTS=""
 
       - name: Build search index
         run: |


### PR DESCRIPTION
It has been incidently disabled in commit 98963ec4898c14ec4d57ce9a8bff0ff103496fb0#