### PR TITLE
examples/glib-2.0/GLib.Test.run.vala: use return value of Test.run

### DIFF
--- a/examples/glib-2.0/GLib.Test.run.vala
+++ b/examples/glib-2.0/GLib.Test.run.vala
@@ -13,8 +13,6 @@ public static int main (string[] args) {
 		// TODO: test
 	});
 
-
 	// Run all tests!
-	Test.run ();
-	return 0;
+	return Test.run ();
 }


### PR DESCRIPTION
In the glib documentation, the example test suite returns the value of
g_test_run(). This seems to be the correct thing to do.