### PR TITLE
Fix GUdev package listing

### DIFF
--- a/documentation/packages.xml
+++ b/documentation/packages.xml
@@ -611,8 +611,8 @@ simple methods via GObject-Introspection
 			<package name="libarchive" home="http://www.libarchive.org/">
 				Library that can create and read several streaming archive formats.
 			</package>
-			<package name="gudev-1.0" home="http://gudev.sourceforge.net/" gir="GUdev-1.0">
-				Gudev is a system device management application for the GNOME desktop.
+			<package name="gudev-1.0" home="https://gitlab.gnome.org/GNOME/libgudev" gir="GUdev-1.0">
+			  GUdev (libgudev) is a library with GObject bindings to libudev, now made independent, after being part of udev itself, and later systemd.
 			</package>
 			<package name="liboobs-1">
 				GObject based interface to system-tools-backends.


### PR DESCRIPTION
## Describe the bug

The homepage listed on [the Valadoc page for`gudev`](https://valadoc.org/gudev-1.0/index.htm) is for a different (dead) project:

<http://gudev.sourceforge.net/>

Rather than the correct URL for `libgudev`:

<https://gitlab.gnome.org/GNOME/libgudev>

## Expected behavior

The links and description should be more in line with those on the corresponding PyGI page for `libgudev`:

<https://lazka.github.io/pgi-docs/GUdev-1.0/index.html>

These in turn appear to be copied from the GNOME Wiki page (which is little more than a bare set of links):

<https://wiki.gnome.org/Projects/libgudev>

## Changed

I changed the "home" URL and also copied the description abstract from [the `libgudev` Gitlab README](https://gitlab.gnome.org/GNOME/libgudev/).