### PR TITLE
Use `code` icon for "markup info"

### DIFF
--- a/data/index.php
+++ b/data/index.php
@@ -81,7 +81,7 @@ if ($first == null || $first === "index") { // Homepage
     <ul>
       <li><a href="https://vala.dev/" target="_blank" title="Vala Official Website"><i class="fa fa-home"></i></a>
       <li><a href="https://www.reddit.com/r/vala/" target="_blank" title="reddit"><i class="fa fa-reddit"></i></a>
-      <li><a href="/markup.htm" title="Markup Info"><i class="fa fa-info-circle"></i></a>
+      <li><a href="/markup.htm" title="Markup Info"><i class="fa fa-code"></i></a>
     </ul>
   </nav>
   <div id="sidebar">


### PR DESCRIPTION
> **Note:** I haven't tested this, but since you're using Font Awesome, it should display correctly.

I personally find the [`info-circle`](https://fontawesome.com/v4/icon/info-circle) icon not terribly clear as shorthand for markup syntax—since, in the global header, one might expect it to give information on the `valadoc.org` site as a whole—so I'm suggesting the use of the [`code`](https://fontawesome.com/v4/icon/code) icon instead.