### PR TITLE
Improve documentation for FileStream.read_line

### DIFF
--- a/documentation/glib-2.0/glib-2.0.valadoc
+++ b/documentation/glib-2.0/glib-2.0.valadoc
@@ -3229,7 +3229,7 @@ GLib.FileStream.read
 GLib.FileStream.write
 
 /**
- * Reads a line, including the terminating character(s), from a IOChannel into a newly-allocated string.
+ * Reads a line, including any line terminating character(s), from a FileStream. Returns a newly-allocated string containing the line, excluding any line terminator.
  */
 GLib.FileStream.read_line
 


### PR DESCRIPTION
The method does not necessarily read line terminating characters (for
example, at EOF).

The string returned does not contain line terminating characters.
