### PR TITLE
Move to a supported Node LTS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [16.x, 18.x, 20.x, 22.x]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x, 22.x]
+        node-version: [18.x, 20.x, 22.x]
 
     steps:
     - uses: actions/checkout@v4
@@ -49,7 +49,7 @@ jobs:
     - name: Install the dependencies
       run: |
         export DEBIAN_FRONTEND=noninteractive
-        curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+        curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
         sudo apt-get update -y
         sudo apt-get install -y --no-install-recommends software-properties-common
         sudo add-apt-repository -y ppa:vala-team/daily

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [16.x, 18.x, 20.x]
 
     steps:
     - uses: actions/checkout@v4
@@ -49,7 +49,7 @@ jobs:
     - name: Install the dependencies
       run: |
         export DEBIAN_FRONTEND=noninteractive
-        curl -fsSL https://deb.nodesource.com/setup_18.x | sudo -E bash -
+        curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
         sudo apt-get update -y
         sudo apt-get install -y --no-install-recommends software-properties-common
         sudo add-apt-repository -y ppa:vala-team/daily

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -qq && apt-get install \
   -qq \
   --no-install-recommends \
-  wget gpung
+  wget gnupg
 RUN wget https://repo.manticoresearch.com/manticore-repo.noarch.deb
 RUN dpkg -i manticore-repo.noarch.deb
 RUN apt-get update -qq && apt-get install \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -qq && apt-get install \
   -qq \
   --no-install-recommends \
-  wget
+  wget gpung
 RUN wget https://repo.manticoresearch.com/manticore-repo.noarch.deb
 RUN dpkg -i manticore-repo.noarch.deb
 RUN apt-get update -qq && apt-get install \


### PR DESCRIPTION
Node 18 (LTS/Hydrogen) went EOL in [October 2023](https://endoflife.date/nodejs) and loses its security support in April 2025.

Node 22 was promoted to an LTS release in October 2024, and we should probably move over.